### PR TITLE
minimal desktop UI for live ADS-B viewing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "python.analysis.extraPaths": [
+    "src"
+  ],
+  "python.testing.pytestArgs": [
+    "src/pocketscope/tests",
+    "tests"
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
   "pydantic>=2.0",
   "numpy>=1.24",
   "msgpack>=1.0",
+  "aiohttp>=3.9",
   # Use pygame-ce on Python 3.13+; fall back to pygame on older versions
   "pygame-ce>=2.5.5; python_version >= '3.13'",
   "pygame>=2.3.0; python_version < '3.13'",
@@ -60,6 +61,7 @@ overrides = [
   { module = "hypothesis.*", ignore_missing_imports = true },
   { module = "msgpack", ignore_missing_imports = true },
   { module = "pygame.*", ignore_missing_imports = true },
+  { module = "aiohttp.*", ignore_missing_imports = true },
   { module = "pocketscope.tests.*", disallow_untyped_decorators = false },
 ]
 

--- a/src/pocketscope/examples/live_view.py
+++ b/src/pocketscope/examples/live_view.py
@@ -1,0 +1,154 @@
+"""
+Live desktop viewer for dump1090 JSON traffic.
+
+How to run:
+  python -m pocketscope.examples.live_view \
+      --url https://adsb.chrispatten.dev/data/aircraft.json \
+      --center 42.00748,-71.20899 \
+      --range 20
+
+This opens a Pygame window and renders live traffic centered on the given
+coordinates. Press Ctrl+C to exit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from collections.abc import Iterable
+
+from pocketscope.core.events import EventBus
+from pocketscope.core.geo import ecef_to_enu, geodetic_to_ecef
+from pocketscope.core.models import AircraftTrack
+from pocketscope.core.time import RealTimeSource
+from pocketscope.core.tracks import TrackService
+from pocketscope.ingest.adsb.json_source import Dump1090JsonSource
+from pocketscope.platform.display.pygame_backend import PygameDisplayBackend
+from pocketscope.render.view_ppi import PpiView, TrackSnapshot
+
+
+def _make_snapshots(
+    tracks: Iterable[AircraftTrack], center_lat: float, center_lon: float
+) -> list[TrackSnapshot]:
+    out: list[TrackSnapshot] = []
+    # Precompute center ECEF
+    _cx, _cy, _cz = geodetic_to_ecef(center_lat, center_lon, 0.0)
+    for tr in tracks:
+        # Use last known lat/lon if present
+        latest_lat = None
+        latest_lon = None
+        if tr.history:
+            latest_lat = tr.history[-1][1]
+            latest_lon = tr.history[-1][2]
+        # Fall back to no position if unknown
+        if latest_lat is None or latest_lon is None:
+            continue
+
+        # Build simple ENU trail from history
+        enu_trail: list[tuple[float, float]] = []
+        for _, lat, lon, _alt in tr.history[-60:]:  # limit to last ~60 samples
+            tx, ty, tz = geodetic_to_ecef(lat, lon, 0.0)
+            e, n, _ = ecef_to_enu(tx, ty, tz, center_lat, center_lon, 0.0)
+            enu_trail.append((e, n))
+
+        course = None
+        if "track_deg" in tr.state and isinstance(tr.state["track_deg"], (int, float)):
+            course = float(tr.state["track_deg"])
+
+        out.append(
+            TrackSnapshot(
+                icao=tr.icao24,
+                lat=latest_lat,
+                lon=latest_lon,
+                callsign=tr.callsign,
+                course_deg=course,
+                trail_enu=enu_trail,
+            )
+        )
+    return out
+
+
+async def render_loop(
+    display: PygameDisplayBackend,
+    view: PpiView,
+    tracks_service: TrackService,
+    *,
+    center_lat: float,
+    center_lon: float,
+    range_nm: float,
+) -> None:
+    # Fixed 30 FPS
+    dt = 1.0 / 30.0
+    while True:
+        canvas = display.begin_frame()
+        # Snapshot tracks and draw
+        active = tracks_service.list_active()
+        snapshots = _make_snapshots(active, center_lat, center_lon)
+        view.range_nm = range_nm
+        view.draw(
+            canvas,
+            size_px=display.size(),
+            center_lat=center_lat,
+            center_lon=center_lon,
+            tracks=snapshots,
+        )
+        display.end_frame()
+        await asyncio.sleep(dt)
+
+
+async def main_async(args: argparse.Namespace) -> None:
+    ts = RealTimeSource()
+    bus = EventBus()
+    tracks = TrackService(bus, ts)
+    src = Dump1090JsonSource(args.url, bus=bus, poll_hz=5.0)
+
+    # Open a window (portrait)
+    display = PygameDisplayBackend(size=(480, 800), create_window=True)
+    view = PpiView()
+
+    await asyncio.gather(
+        src.run(),
+        tracks.run(),
+        render_loop(
+            display,
+            view,
+            tracks,
+            center_lat=args.center[0],
+            center_lon=args.center[1],
+            range_nm=args.range,
+        ),
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="PocketScope Live Viewer")
+    p.add_argument(
+        "--url",
+        default="https://adsb.chrispatten.dev/data/aircraft.json",
+        help="dump1090 aircraft.json URL",
+    )
+    p.add_argument(
+        "--center",
+        type=lambda s: tuple(map(float, s.split(","))),
+        default=(42.00748, -71.20899),
+        help="Center lat,lon",
+    )
+    p.add_argument(
+        "--range",
+        type=float,
+        default=20.0,
+        help="Range in NM",
+    )
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    try:
+        asyncio.run(main_async(args))
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pocketscope/ingest/adsb/__init__.py
+++ b/src/pocketscope/ingest/adsb/__init__.py
@@ -1,1 +1,5 @@
-# ADS-B ingestion source
+"""ADS-B ingest sources."""
+
+from .json_source import Dump1090JsonSource
+
+__all__ = ["Dump1090JsonSource"]

--- a/src/pocketscope/ingest/adsb/json_source.py
+++ b/src/pocketscope/ingest/adsb/json_source.py
@@ -1,0 +1,261 @@
+"""
+Dump1090 JSON polling source.
+
+This module provides Dump1090JsonSource which periodically polls a dump1090
+"aircraft.json" endpoint and publishes normalized AdsbMessage events to the
+EventBus. It implements light caching via ETag/Last-Modified and backs off on
+transient failures.
+
+Expected dump1090 fields (per-aircraft object):
+ - hex: ICAO24 in lowercase hex (required)
+ - flight: Callsign (optional, may include trailing spaces)
+ - lat, lon: Position (optional; publish state without position if missing)
+ - alt_baro: Baro altitude in feet (optional)
+ - alt_geom: Geometric altitude in feet (optional)
+ - gs: Ground speed in knots (optional)
+ - track: Course over ground in degrees true (optional)
+ - baro_rate: Vertical rate (ft/min) (optional)
+ - squawk: Transponder code as string (optional)
+ - nic: Navigation Integrity Category (optional)
+ - nac_p: Navigation Accuracy Category for Position (optional)
+ - seen, seen_pos: Seconds since last overall/pos update (optional; used to skip stale)
+
+Top-level fields:
+ - now: Wall time (seconds since epoch). Used for message timestamp if present.
+
+Only aircraft with a valid 6-hex ICAO24 are published. Entries with obviously
+stale timestamps (seen/seen_pos > 60 seconds) are skipped.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import aiohttp
+
+from pocketscope.core.events import EventBus, pack
+from pocketscope.core.models import AdsbMessage
+
+__all__ = ["Dump1090JsonSource"]
+
+logger = logging.getLogger(__name__)
+
+
+def _is_valid_icao24(s: Any) -> bool:
+    if not isinstance(s, str):
+        return False
+    s = s.strip().lower()
+    if len(s) != 6:
+        return False
+    for ch in s:
+        if ch not in "0123456789abcdef":
+            return False
+    return True
+
+
+def _coerce_float(v: Any) -> Optional[float]:
+    try:
+        if v is None:
+            return None
+        # Reject NaN/inf implicitly by float() then isfinite? Keep simple here.
+        return float(v)
+    except Exception:
+        return None
+
+
+def _coerce_int(v: Any) -> Optional[int]:
+    try:
+        if v is None:
+            return None
+        return int(v)
+    except Exception:
+        return None
+
+
+@dataclass(slots=True)
+class _CacheState:
+    etag: Optional[str] = None
+    last_modified: Optional[str] = None
+
+
+class Dump1090JsonSource:
+    """
+    Polls dump1090 'aircraft.json' and publishes AdsbMessage to topic 'adsb.msg'.
+    Default poll rate: 5 Hz (every 0.2 s). Handles transient errors with backoff.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        bus: EventBus,
+        poll_hz: float = 5.0,
+        topic: str = "adsb.msg",
+        session: Optional[aiohttp.ClientSession] = None,
+        timeout_s: float = 3.0,
+        verify_tls: bool = True,
+    ) -> None:
+        # Support relative path via env var base
+        base = os.environ.get("DUMP1090_BASE_URL")
+        if url.startswith("/") and base:
+            self._url = base.rstrip("/") + url
+        else:
+            self._url = url
+
+        self._bus = bus
+        self._topic = topic
+        self._interval = 1.0 / max(0.1, float(poll_hz))
+        self._timeout_s = float(timeout_s)
+        self._verify_tls = bool(verify_tls)
+        self._ext_session = session
+        self._session: Optional[aiohttp.ClientSession] = None
+        self._running = False
+        self._stop_event = asyncio.Event()
+        self._cache = _CacheState()
+
+    async def run(self) -> None:
+        if self._running:
+            return
+        self._running = True
+
+        # Prepare session if not provided
+        if self._ext_session is not None:
+            self._session = self._ext_session
+        else:
+            timeout = aiohttp.ClientTimeout(total=self._timeout_s)
+            connector = aiohttp.TCPConnector(ssl=self._verify_tls)
+            self._session = aiohttp.ClientSession(timeout=timeout, connector=connector)
+
+        backoff = 0.2
+        max_backoff = 2.0
+
+        try:
+            while not self._stop_event.is_set():
+                try:
+                    await self._poll_once()
+                    # Reset backoff on success
+                    backoff = 0.2
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    logger.warning(f"dump1090 poll error: {e}")
+                    # Exponential backoff up to max_backoff
+                    await asyncio.sleep(backoff)
+                    backoff = min(max_backoff, backoff * 2.0)
+                # Maintain cadence
+                await asyncio.sleep(self._interval)
+        finally:
+            if self._session and self._ext_session is None:
+                try:
+                    await self._session.close()
+                except Exception:
+                    pass
+            self._running = False
+
+    async def stop(self) -> None:
+        self._stop_event.set()
+
+    async def _poll_once(self) -> bool:
+        assert self._session is not None
+        headers: dict[str, str] = {}
+        if self._cache.etag:
+            headers["If-None-Match"] = self._cache.etag
+        if self._cache.last_modified:
+            headers["If-Modified-Since"] = self._cache.last_modified
+
+        async with self._session.get(self._url, headers=headers) as resp:
+            if resp.status == 304:
+                return False
+            resp.raise_for_status()
+
+            # Cache headers
+            etag = resp.headers.get("ETag")
+            if etag:
+                self._cache.etag = etag
+            lm = resp.headers.get("Last-Modified")
+            if lm:
+                self._cache.last_modified = lm
+
+            # Parse JSON payload
+            # We read text then json.loads to avoid aiohttp's type ignoring
+            text = await resp.text()
+            data = json.loads(text)
+            self._handle_payload(data)
+            return True
+
+    def _handle_payload(self, data: dict[str, Any]) -> None:
+        # Determine timestamp
+        now_s = _coerce_float(data.get("now"))
+        if now_s is None:
+            from time import time as _now
+
+            now_s = _now()
+        ts = datetime.fromtimestamp(float(now_s), tz=timezone.utc)
+
+        ac_list = data.get("aircraft")
+        if not isinstance(ac_list, list):
+            return
+
+        for ac in ac_list:
+            if not isinstance(ac, dict):  # defensive
+                continue
+            icao = ac.get("hex")
+            if not _is_valid_icao24(icao):
+                continue
+            icao = str(icao).strip().lower()
+
+            # Staleness check
+            seen = _coerce_float(ac.get("seen")) or 0.0
+            seen_pos = _coerce_float(ac.get("seen_pos")) or 0.0
+            if seen > 60.0 or seen_pos > 60.0:
+                continue
+
+            callsign_raw = ac.get("flight")
+            callsign = None
+            if isinstance(callsign_raw, str):
+                callsign = callsign_raw.strip() or None
+
+            lat = _coerce_float(ac.get("lat"))
+            lon = _coerce_float(ac.get("lon"))
+
+            baro_alt = _coerce_float(ac.get("alt_baro"))
+            geo_alt = _coerce_float(ac.get("alt_geom"))
+            gs = _coerce_float(ac.get("gs"))
+            track = _coerce_float(ac.get("track"))
+            vr = _coerce_float(ac.get("baro_rate"))
+            squawk = ac.get("squawk") if isinstance(ac.get("squawk"), str) else None
+            nic = _coerce_int(ac.get("nic"))
+            nacp = _coerce_int(ac.get("nac_p"))
+
+            msg = AdsbMessage(
+                ts=ts,
+                icao24=icao,
+                callsign=callsign,
+                lat=lat,
+                lon=lon,
+                baro_alt=baro_alt,
+                geo_alt=geo_alt,
+                ground_speed=gs,
+                track_deg=track,
+                vertical_rate=vr,
+                squawk=squawk,
+                nic=nic,
+                nacp=nacp,
+                src="JSON",
+            )
+
+            # Serialize with ISO timestamp for msgpack
+            msg_dict = msg.model_dump()
+            msg_dict["ts"] = msg.ts.isoformat()
+            # Fire-and-forget publish (async caller)
+            # Use create_task? EventBus.publish is async; call directly but do
+            # not await here. However, we're in sync context; schedule
+            # publishing via asyncio.create_task to avoid blocking on many
+            # aircraft.
+            asyncio.create_task(self._bus.publish(self._topic, pack(msg_dict)))

--- a/src/pocketscope/tests/data/aircraft_sample.json
+++ b/src/pocketscope/tests/data/aircraft_sample.json
@@ -1,0 +1,50 @@
+{
+  "now": 1725019200,
+  "aircraft": [
+    {
+      "hex": "a1b2c3",
+      "flight": "JBU123 ",
+      "lat": 42.01,
+      "lon": -71.20,
+      "alt_baro": 35000,
+      "alt_geom": 35200,
+      "gs": 420.5,
+      "track": 270.0,
+      "baro_rate": -512,
+      "squawk": "1234",
+      "nic": 8,
+      "nac_p": 9,
+      "seen": 1.2,
+      "seen_pos": 0.4
+    },
+    {
+      "hex": "d4e5f6",
+      "flight": "DAL456",
+      "alt_baro": 28000,
+      "gs": 380.0,
+      "track": 90.0,
+      "baro_rate": 256,
+      "squawk": "7700",
+      "nic": 7,
+      "nac_p": 8,
+      "seen": 0.5,
+      "seen_pos": 0.5
+    },
+    {
+      "hex": "zzzzzz",
+      "flight": "BADHEX",
+      "lat": 0,
+      "lon": 0,
+      "seen": 0.1,
+      "seen_pos": 0.1
+    },
+    {
+      "hex": "abc123",
+      "flight": "STALE1",
+      "lat": 42.05,
+      "lon": -71.25,
+      "seen": 120.0,
+      "seen_pos": 120.0
+    }
+  ]
+}

--- a/tests/data/aircraft_sample.json
+++ b/tests/data/aircraft_sample.json
@@ -1,0 +1,50 @@
+{
+  "now": 1725019200,
+  "aircraft": [
+    {
+      "hex": "a1b2c3",
+      "flight": "JBU123 ",
+      "lat": 42.01,
+      "lon": -71.20,
+      "alt_baro": 35000,
+      "alt_geom": 35200,
+      "gs": 420.5,
+      "track": 270.0,
+      "baro_rate": -512,
+      "squawk": "1234",
+      "nic": 8,
+      "nac_p": 9,
+      "seen": 1.2,
+      "seen_pos": 0.4
+    },
+    {
+      "hex": "d4e5f6",
+      "flight": "DAL456",
+      "alt_baro": 28000,
+      "gs": 380.0,
+      "track": 90.0,
+      "baro_rate": 256,
+      "squawk": "7700",
+      "nic": 7,
+      "nac_p": 8,
+      "seen": 0.5,
+      "seen_pos": 0.5
+    },
+    {
+      "hex": "zzzzzz",
+      "flight": "BADHEX",
+      "lat": 0,
+      "lon": 0,
+      "seen": 0.1,
+      "seen_pos": 0.1
+    },
+    {
+      "hex": "abc123",
+      "flight": "STALE1",
+      "lat": 42.05,
+      "lon": -71.25,
+      "seen": 120.0,
+      "seen_pos": 120.0
+    }
+  ]
+}

--- a/tests/ingest/test_dump1090_json_source.py
+++ b/tests/ingest/test_dump1090_json_source.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+from aiohttp import web
+
+from pocketscope.core.events import EventBus, unpack
+from pocketscope.core.models import AdsbMessage
+from pocketscope.ingest.adsb.json_source import Dump1090JsonSource
+
+
+def load_fixture(name: str) -> dict[str, Any]:
+    p = Path(__file__).resolve().parents[1] / "data" / name
+    with p.open("r", encoding="utf-8") as f:
+        data: dict[str, Any] = json.load(f)
+        return data
+
+
+async def _start_test_server(
+    responses: list[tuple[int, dict[str, Any]]]
+) -> tuple[web.AppRunner, web.TCPSite, str]:
+    """Start a simple aiohttp server that serves a sequence of JSON responses.
+
+    Each call pops the next (status, body) tuple; if exhausted, repeat last.
+    """
+    app = web.Application()
+
+    state = {"idx": 0}
+
+    async def handler(request: web.Request) -> web.Response:
+        i = state["idx"]
+        if i >= len(responses):
+            i = len(responses) - 1
+        status, body = responses[i]
+        state["idx"] = min(state["idx"] + 1, len(responses))
+        return web.json_response(body, status=status)
+
+    app.router.add_get("/data/aircraft.json", handler)
+
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    # mypy: aiohttp's private attribute is not typed; narrow at runtime
+    server = site._server
+    assert server is not None
+    sockets = getattr(server, "sockets", None)
+    assert sockets, "Server sockets not available"
+    port = sockets[0].getsockname()[1]
+    url = f"http://127.0.0.1:{port}/data/aircraft.json"
+    return runner, site, url
+
+
+@pytest.mark.asyncio
+async def test_dump1090_json_source_maps_and_publishes(tmp_path: Path) -> None:
+    # Prepare fixture and server
+    fixture = load_fixture("aircraft_sample.json")
+    runner, site, url = await _start_test_server([(200, fixture)])
+
+    bus = EventBus()
+    sub = bus.subscribe("adsb.msg")
+    src = Dump1090JsonSource(url, bus=bus, poll_hz=20.0)
+
+    task = asyncio.create_task(src.run())
+
+    # Collect a few messages
+    msgs: list[AdsbMessage] = []
+
+    try:
+        # Wait for a couple publishes
+        for _ in range(5):
+            env = await asyncio.wait_for(sub.__anext__(), timeout=2.0)
+            d = unpack(env.payload)
+            # Restore ts for validation
+            d["ts"] = datetime.fromisoformat(d["ts"].replace("Z", "+00:00"))
+            msgs.append(AdsbMessage.model_validate(d))
+            if len(msgs) >= 2:
+                break
+
+        assert msgs, "No messages received"
+        # Pick the first with lat/lon for stronger checks
+        m = None
+        for x in msgs:
+            if x.lat is not None and x.lon is not None:
+                m = x
+                break
+        assert m is not None
+        # Validate basic mapping
+        assert len(m.icao24) == 6 and m.icao24 == m.icao24.lower()
+        # These fields come from the fixture
+        assert isinstance(m.lat, float)
+        assert isinstance(m.lon, float)
+        # Optional numeric fields preserved when present
+        if m.baro_alt is not None:
+            assert isinstance(m.baro_alt, float)
+        if m.ground_speed is not None:
+            assert isinstance(m.ground_speed, float)
+        if m.track_deg is not None:
+            assert isinstance(m.track_deg, float)
+
+    finally:
+        await src.stop()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        await sub.close()
+        await bus.close()
+        await runner.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_dump1090_json_source_backoff_and_recovery() -> None:
+    # First response 500, then good
+    fixture = load_fixture("aircraft_sample.json")
+    runner, site, url = await _start_test_server(
+        [(500, {"error": "boom"}), (200, fixture)]
+    )
+
+    bus = EventBus()
+    sub = bus.subscribe("adsb.msg")
+    src = Dump1090JsonSource(url, bus=bus, poll_hz=20.0)
+
+    task = asyncio.create_task(src.run())
+
+    try:
+        # First poll fails; ensure we still eventually get a message
+        env = await asyncio.wait_for(sub.__anext__(), timeout=5.0)
+        d = unpack(env.payload)
+        assert _is_valid_icao(d["icao24"])  # helper below
+    finally:
+        await src.stop()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        await sub.close()
+        await bus.close()
+        await runner.cleanup()
+
+
+def _is_valid_icao(s: Any) -> bool:
+    return isinstance(s, str) and len(s) == 6 and s == s.lower()


### PR DESCRIPTION
This PR introduces a minimal desktop UI for live ADS-B viewing and a new dump1090 JSON ingestion source, along with tests, docs, and small platform improvements.

## Summary
- New live ADS-B ingestion via dump1090 `aircraft.json` using aiohttp
- Minimal on-screen PPI viewer example powered by the rendering pipeline
- Headless-friendly Pygame display backend tweaks
- Documentation expanded with architecture and usage examples
- New tests and sample data for ingestion and rendering
- Dependency updates in `pyproject.toml` (aiohttp, pygame/pygame-ce split)

## Changes

### Ingestion
- Added `src/pocketscope/ingest/adsb/json_source.py`
  - Class: `Dump1090JsonSource`
  - Polls `aircraft.json` using `aiohttp` with timeouts
  - Conditional requests via `ETag` and `If-Modified-Since`
  - Exponential backoff on failures, automatic recovery
  - Filters stale entries using `seen/seen_pos > 60s`
  - Normalizes fields into `AdsbMessage` and publishes to topic `adsb.msg`
  - Configurable options: `poll_hz` (default 5.0), `timeout_s`, `verify_tls`, `topic`
  - Supports `DUMP1090_BASE_URL` when `url` begins with `/`

### Example UI
- Added `src/pocketscope/examples/live_view.py`
  - Simple north-up PPI viewer rendering live tracks in a Pygame window
  - Usage:
    - `python -m pocketscope.examples.live_view --url http://<host>:8080/data/aircraft.json --center <lat,lon> --range <nm>`
  - Integrates: `Dump1090JsonSource` + `TrackService` + `PpiView` + `PygameDisplayBackend`
  - 30 FPS render loop; Ctrl+C to exit

### Rendering / Platform
- Updated `src/pocketscope/platform/display/pygame_backend.py`
  - Offscreen surface (SRCALPHA) always available; optional window via `create_window=True`
  - Headless-friendly with `SDL_VIDEODRIVER=dummy`; also sets `SDL_AUDIODRIVER=dummy`
  - Deterministic font selection via `pygame.font.Font(None, size)`
  - Antialiased text rendering; single-point polyline draws a dot

### Documentation
- Expanded `README.md` with:
  - Live ADS-B ingestion docs and code examples for `Dump1090JsonSource`
  - PPI view and rendering pipeline overview
  - Architecture sections for EventBus, Time, Tracks, Geodesy, and more

### Tests & Sample Data
- Added tests:
  - `tests/ingest/test_dump1090_json_source.py` (covers mapping, backoff/recovery)
- Added fixtures:
  - `tests/data/aircraft_sample.json` (duplicated under `src/pocketscope/tests/data/`)
- Golden-frame and existing test suites remain intact

### Tooling
- Added `.vscode/settings.json` for local dev convenience

### Packaging
- Updated `pyproject.toml`
  - Dependencies: `aiohttp>=3.9`, `pydantic>=2.0`, `numpy>=1.24`, `msgpack>=1.0`
  - Python 3.11+
  - Pygame selection:
    - `pygame-ce>=2.5.5` for Python 3.13+
    - `pygame>=2.3.0` for Python < 3.13

## How to run the live viewer
- Install project dependencies (Python 3.11+)
- Optional for headless: set `SDL_VIDEODRIVER=dummy`
- Run:
  - `python -m pocketscope.examples.live_view --url http://127.0.0.1:8080/data/aircraft.json --center <lat,lon> --range <nm>`
- Exit with Ctrl+C

## Environment variables
- `DUMP1090_BASE_URL`: If set and the provided `url` starts with `/`, it will be prefixed with this base (e.g., `http://host:8080`)
- `SDL_VIDEODRIVER`: Set to `dummy` for headless operation (tests/CI)

## Backwards compatibility
- Additive changes only; no breaking public API changes
- New optional runtime dependencies for live ingestion and UI; core functionality unaffected if not used

## Risks and mitigations
- Network instability: handled via short timeouts and exponential backoff
- Bandwidth/CPU: mitigated via caching headers (ETag/Last-Modified) and moderate poll rate (default 5 Hz)
- Data quality: stale aircraft entries are filtered by `seen/seen_pos`

## Limitations / follow-ups
- Only a subset of dump1090 fields are normalized today; extend as needed
- Per-aircraft publish is scheduled via `asyncio.create_task` in bursts; consider batching or backpressure if needed for very busy airspace
- Live viewer is minimal by design; planned features include interactions, labels, and filtering

## Testing
- Test paths configured under `src/pocketscope/tests` via `pytest.ini` settings
- New ingestion tests: `tests/ingest/test_dump1090_json_source.py`
- Run tests with pytest; for render tests in headless environments, ensure `SDL_VIDEODRIVER=dummy`

## Acceptance criteria
- Live dump1090 ingestion publishes normalized `AdsbMessage` to `adsb.msg`
- Example live viewer renders tracks around a configurable center within a set range
- Unit tests pass locally for ingestion; no regressions in existing suites

## Release notes
- feat(adsb): dump1090 JSON source + minimal live PPI viewer; tests; aiohttp; pygame window; docs