### PR TITLE
ATC-style data blocks with leader lines; wired into PPI/live viewer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,4 +69,5 @@ overrides = [
 addopts = "-ra -q"
 testpaths = [
   "src/pocketscope/tests",
+  "tests",
 ]

--- a/src/pocketscope/render/fonts.py
+++ b/src/pocketscope/render/fonts.py
@@ -1,0 +1,63 @@
+"""Font utilities for monospaced rendering.
+
+Provides a simple helper to obtain a monospaced font handle from pygame
+with a fallback chain across common system fonts. Rendering itself is done
+via the abstract Canvas.text API, so this module is primarily useful for
+backends that need an explicit font handle.
+"""
+
+from __future__ import annotations
+
+
+class FontHandle:
+    """Lightweight wrapper for a backend font object.
+
+    The concrete type depends on the active backend (e.g., pygame Font).
+    This class exists to avoid importing pygame at call sites.
+    """
+
+    def __init__(self, obj: object) -> None:  # pragma: no cover - trivial wrapper
+        self.obj = obj
+
+
+def get_mono(size_px: int) -> FontHandle:
+    """Return a monospaced font handle at the given pixel size.
+
+    Attempts a preferred list of monospaced faces and falls back to the
+    default monospace if necessary. Uses pygame (or pygame-ce) when available.
+
+    Fallback chain: ["DejaVu Sans Mono","Menlo","Consolas","Courier New","monospace"].
+
+    Notes
+    -----
+    - Callers are not required to use the returned handle with Canvas.text,
+      since Canvas abstracts font selection. This helper is provided for
+      backends that accept font objects explicitly.
+    """
+
+    try:
+        import pygame
+
+        pygame.font.init()
+        names = [
+            "DejaVu Sans Mono",
+            "Menlo",
+            "Consolas",
+            "Courier New",
+            "monospace",
+        ]
+        # Try system font matching first
+        for name in names:
+            try:
+                f = pygame.font.SysFont(name, size_px)
+                if f is not None:
+                    return FontHandle(f)
+            except Exception:
+                continue
+        # Fall back to default font
+        return FontHandle(pygame.font.Font(None, size_px))
+    except Exception:
+        # If pygame isn't available in the test environment, return a stub.
+        # Rendering will still proceed via Canvas.text which doesn't require
+        # this handle.
+        return FontHandle(object())

--- a/src/pocketscope/render/labels.py
+++ b/src/pocketscope/render/labels.py
@@ -1,0 +1,293 @@
+"""Data block formatting and layout for ATC-style labels.
+
+This module provides:
+
+- DataBlockFormatter: Formats three-line labels in standard and expanded
+  modes using fixed-width numeric fields with specific rules for altitude,
+  bearing, and speed. All numeric components are zero-padded as specified.
+  Altitude is in hundreds of feet with on-ground heuristic and vertical
+  trend suffix; bearing is relative to ownship (0..359) padded to 3 digits;
+  speed is rounded to nearest 10 kt and shown as two digits representing
+  tens of knots.
+
+- DataBlockLayout: Places label blocks near aircraft anchors using fixed
+  offset directions (NE, SE, NW, SW). On collision with any previously
+  placed block, the layout engine nudges the candidate position outward in
+  a small spiral (increasing radius) while keeping the block on screen.
+    Leader-line anchor semantics: each item provides an anchor_px (aircraft
+  glyph position in screen pixels). The final placement returns the top-left
+  block corner and an anchor point for the leader line.
+
+Default usage in the UI
+-----------------------
+- The live viewer enables data blocks by default. ``PpiView`` builds
+    ``labels.TrackSnapshot`` inputs from track state and asks
+    ``DataBlockFormatter.format_standard`` for three text lines. These are laid
+    out with ``DataBlockLayout.place_blocks``, and leader lines are rendered
+    to the nearest block edge.
+
+Inputs/outputs
+--------------
+- Inputs to the formatter are domain-agnostic numerical fields (altitudes,
+    ground speed, vertical rate) plus position for bearing relative to ownship.
+- Outputs are always exactly three strings (standard or expanded form).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Sequence, Tuple
+
+from pocketscope.core.geo import range_bearing_from
+
+
+@dataclass
+class OwnshipRef:
+    lat: float
+    lon: float
+
+
+@dataclass
+class TrackSnapshot:
+    icao24: str
+    callsign: Optional[str]
+    lat: Optional[float]
+    lon: Optional[float]
+    geo_alt_ft: Optional[float]
+    baro_alt_ft: Optional[float]
+    ground_speed_kt: Optional[float]
+    vertical_rate_fpm: Optional[float]
+    emitter_type: Optional[str] = None
+    pinned: bool = False
+    focused: bool = False
+
+
+@dataclass
+class BlockPlacement:
+    # top-left corner of the block in pixels
+    x: int
+    y: int
+    # anchor point for leader line (aircraft glyph screen px)
+    anchor_px: Tuple[int, int]
+    # 3 lines of rendered text
+    lines: Tuple[str, str, str]
+    expanded: bool
+
+
+class DataBlockFormatter:
+    """Formatter for ATC-style three-line data blocks.
+
+    Rules
+    -----
+    - Line count: always three lines.
+    - Standard mode (default):
+        1. CALLSIGN if present else ICAO (uppercased).
+        2. Altitude in hundreds of feet, zero-padded 3 digits; select
+           geometric altitude if available else barometric. If unknown or on
+           ground (<100 ft), show 000. Append '+' if vertical_rate_fpm > +500,
+           '-' if < -500, else nothing.
+        3. Bearing and speed: "BRG SPD" where BRG is relative to ownship
+           0..359 padded to 3 digits; SPD is ground speed rounded to nearest
+           10 kt, shown as two digits (tens). Unknown speed => 00.
+    - Expanded mode (focused or pinned):
+        1. "CALLSIGN | ICAO" (uppercase; ICAO always shown).
+        2. "ALT[±] | VS" where ALT as above; VS is signed fpm (integer).
+        3. "BRG SPD | TYPE" where TYPE is emitter category (e.g., L2J);
+           if unknown, omit content after '|'.
+    """
+
+    def __init__(self, ownship: OwnshipRef):
+        self.own = ownship
+
+    @staticmethod
+    def _format_alt_hundreds(
+        geo_alt_ft: Optional[float],
+        baro_alt_ft: Optional[float],
+        vr_fpm: Optional[float],
+    ) -> str:
+        alt_ft = geo_alt_ft if geo_alt_ft is not None else baro_alt_ft
+        if alt_ft is None or alt_ft < 100.0:
+            base = 0
+        else:
+            base = int(round(alt_ft / 100.0))
+        base_clamped = max(0, min(999, base))
+        alt_str = f"{base_clamped:03d}"
+        if vr_fpm is not None:
+            if vr_fpm > 500.0:
+                return alt_str + "+"
+            if vr_fpm < -500.0:
+                return alt_str + "-"
+        return alt_str
+
+    @staticmethod
+    def _format_speed_tens(gs_kt: Optional[float]) -> str:
+        if gs_kt is None or not (gs_kt == gs_kt):  # NaN-safe
+            return "00"
+        tens = int(round(gs_kt / 10.0))
+        tens = max(0, min(99, tens))
+        return f"{tens:02d}"
+
+    def bearing_deg_rel(self, own: OwnshipRef, lat: float, lon: float) -> int:
+        _, brg = range_bearing_from(own.lat, own.lon, lat, lon)
+        return int(round(brg)) % 360
+
+    def _format_brg_spd(self, t: TrackSnapshot) -> str:
+        if t.lat is None or t.lon is None:
+            brg = 0
+        else:
+            brg = self.bearing_deg_rel(self.own, t.lat, t.lon)
+        brg_str = f"{int(brg)%360:03d}"
+        spd_str = self._format_speed_tens(t.ground_speed_kt)
+        return f"{brg_str} {spd_str}"
+
+    def format_standard(self, t: TrackSnapshot) -> Tuple[str, str, str]:
+        ident = (t.callsign or t.icao24).upper()
+        alt = self._format_alt_hundreds(
+            t.geo_alt_ft, t.baro_alt_ft, t.vertical_rate_fpm
+        )
+        line2 = alt
+        line3 = self._format_brg_spd(t)
+        return (ident, line2, line3)
+
+    def format_expanded(self, t: TrackSnapshot) -> Tuple[str, str, str]:
+        ident = (t.callsign or t.icao24).upper()
+        left = f"{ident} | {t.icao24.upper()}"
+        alt = self._format_alt_hundreds(
+            t.geo_alt_ft, t.baro_alt_ft, t.vertical_rate_fpm
+        )
+        vs = 0 if t.vertical_rate_fpm is None else int(round(t.vertical_rate_fpm))
+        line2 = f"{alt} | {vs:+d}"
+        brg_spd = self._format_brg_spd(t)
+        typ = t.emitter_type or ""
+        if typ:
+            line3 = f"{brg_spd} | {typ}"
+        else:
+            line3 = f"{brg_spd} | "
+        return (left, line2, line3)
+
+
+class DataBlockLayout:
+    """
+    Places blocks around aircraft with leader lines and simple overlap nudge.
+
+    Strategy
+    --------
+    - Each item provides an anchor (aircraft glyph px), lines, and expanded flag.
+    - We measure the block (monospace assumption): width = max line length * char_w,
+      height = 3 * font_h + 2 * line_gap.
+    - Try offset quadrants in fixed order: NE(dx=+8,dy=-8), SE, NW, SW.
+    - On collision with any previously placed bbox, nudge outward along a
+      small spiral by increasing radius while circling around the initial
+      quadrant center. Attempts are capped to keep runtime bounded. If still
+      colliding, we keep the last candidate position.
+    - Block bboxes are clamped to stay on-screen with small margins.
+    """
+
+    def __init__(
+        self,
+        canvas_size: Tuple[int, int],
+        font_px: int = 12,
+        line_gap_px: int = 2,
+        block_pad_px: int = 2,
+    ) -> None:
+        self.w, self.h = int(canvas_size[0]), int(canvas_size[1])
+        self.font_px = int(font_px)
+        self.line_gap_px = int(line_gap_px)
+        self.block_pad_px = int(block_pad_px)
+        # Assume a typical monospace aspect (approx). Fine for layout tests.
+        self.char_w = max(6, int(round(self.font_px * 0.6)))
+        self.line_h = self.font_px + self.line_gap_px
+
+    def measure(self, lines: Sequence[str]) -> Tuple[int, int]:
+        max_cols = max((len(s) for s in lines), default=0)
+        width = max_cols * self.char_w + 2 * self.block_pad_px
+        height = 3 * self.font_px + 2 * self.line_gap_px + 2 * self.block_pad_px
+        return (width, height)
+
+    @staticmethod
+    def _intersects(a: Tuple[int, int, int, int], b: Tuple[int, int, int, int]) -> bool:
+        ax, ay, aw, ah = a
+        bx, by, bw, bh = b
+        return not (ax + aw <= bx or bx + bw <= ax or ay + ah <= by or by + bh <= ay)
+
+    def _clamp_bbox(self, x: int, y: int, w: int, h: int) -> Tuple[int, int]:
+        x = max(0, min(self.w - w, x))
+        y = max(0, min(self.h - h, y))
+        return (x, y)
+
+    def place_blocks(
+        self, items: Sequence[tuple[Tuple[int, int], Tuple[str, str, str], bool]]
+    ) -> list[BlockPlacement]:
+        placements: list[BlockPlacement] = []
+        occupied: list[Tuple[int, int, int, int]] = []  # x,y,w,h
+
+        # Fixed initial offsets for quadrants
+        offsets = [
+            (8, -8),  # NE
+            (8, 8),  # SE
+            (-8, -8),  # NW
+            (-8, 8),  # SW
+        ]
+
+        for anchor, lines, expanded in items:
+            bw, bh = self.measure(lines)
+            ax, ay = anchor
+            # Candidate positions for top-left based on quadrant
+            quads = [
+                (ax + offsets[0][0], ay + offsets[0][1] - bh),  # NE above-right
+                (ax + offsets[1][0], ay + offsets[1][1]),  # SE below-right
+                (ax + offsets[2][0] - bw, ay + offsets[2][1] - bh),  # NW above-left
+                (ax + offsets[3][0] - bw, ay + offsets[3][1]),  # SW below-left
+            ]
+
+            best_x, best_y = quads[0]
+
+            for qx, qy in quads:
+                # Nudge spiral parameters
+                step = 6
+                max_attempts = 40
+                attempts = 0
+                x, y = qx, qy
+
+                def bbox_at(px: int, py: int) -> Tuple[int, int, int, int]:
+                    return (px, py, bw, bh)
+
+                # Try initial clamped pos
+                x, y = self._clamp_bbox(x, y, bw, bh)
+                box = bbox_at(x, y)
+                # Check collision
+                collides = any(self._intersects(box, b) for b in occupied)
+
+                while collides and attempts < max_attempts:
+                    # Spiral: move outward in a square spiral pattern
+                    # Right, down, left, up... with increasing radius
+                    r = 1 + attempts // 4
+                    dir_idx = attempts % 4
+                    dx = [step * r, 0, -step * r, 0][dir_idx]
+                    dy = [0, step * r, 0, -step * r][dir_idx]
+                    x = qx + dx
+                    y = qy + dy
+                    x, y = self._clamp_bbox(x, y, bw, bh)
+                    box = bbox_at(x, y)
+                    collides = any(self._intersects(box, b) for b in occupied)
+                    attempts += 1
+
+                if not collides:
+                    best_x, best_y = x, y
+                    break
+                else:
+                    # Keep the last candidate as fallback if nothing fits
+                    best_x, best_y = x, y
+
+            placements.append(
+                BlockPlacement(
+                    x=int(best_x),
+                    y=int(best_y),
+                    anchor_px=(int(ax), int(ay)),
+                    lines=(lines[0], lines[1], lines[2]),
+                    expanded=bool(expanded),
+                )
+            )
+            occupied.append((int(best_x), int(best_y), bw, bh))
+
+        return placements

--- a/tests/render/test_labels_format.py
+++ b/tests/render/test_labels_format.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pocketscope.core.geo import dest_point
+from pocketscope.render.labels import DataBlockFormatter, OwnshipRef, TrackSnapshot
+
+
+def make_track(**kw: Any) -> TrackSnapshot:
+    return TrackSnapshot(
+        icao24=kw.get("icao24", "abc123"),
+        callsign=kw.get("callsign", "DAL123"),
+        lat=kw.get("lat", 42.0),
+        lon=kw.get("lon", -71.0),
+        geo_alt_ft=kw.get("geo_alt_ft", None),
+        baro_alt_ft=kw.get("baro_alt_ft", None),
+        ground_speed_kt=kw.get("ground_speed_kt", None),
+        vertical_rate_fpm=kw.get("vertical_rate_fpm", None),
+        emitter_type=kw.get("emitter_type", None),
+        pinned=kw.get("pinned", False),
+        focused=kw.get("focused", False),
+    )
+
+
+def test_alt_formatting_rules() -> None:
+    fmt = DataBlockFormatter(OwnshipRef(42.0, -71.0))
+
+    # 2600 ft with +600 fpm -> 026+
+    t = make_track(baro_alt_ft=2600.0, vertical_rate_fpm=600.0)
+    l1, l2, l3 = fmt.format_standard(t)
+    assert l2 == "026+"
+
+    # 35000 ft 0 fpm -> 350
+    t = make_track(baro_alt_ft=35000.0, vertical_rate_fpm=0.0)
+    l1, l2, l3 = fmt.format_standard(t)
+    assert l2 == "350"
+
+    # unknown alt or 50 ft -> 000
+    t = make_track(baro_alt_ft=None)
+    assert fmt.format_standard(t)[1] == "000"
+    t = make_track(baro_alt_ft=50.0)
+    assert fmt.format_standard(t)[1] == "000"
+
+
+def test_speed_rounding() -> None:
+    fmt = DataBlockFormatter(OwnshipRef(42.0, -71.0))
+
+    def spd(gs: float | None) -> str:
+        t = make_track(ground_speed_kt=gs)
+        return fmt._format_brg_spd(t).split()[1]
+
+    assert spd(447.0) == "45"
+    assert spd(452.0) == "45"
+    assert spd(455.0) == "46"
+    assert spd(None) == "00"
+
+
+def test_bearing_zero_padded() -> None:
+    own = OwnshipRef(42.00748, -71.20899)
+    fmt = DataBlockFormatter(own)
+    # Take a destination roughly NE at 45 deg, 1 nm
+    lat2, lon2 = dest_point(own.lat, own.lon, 45.0, 1.0)
+    t = make_track(lat=lat2, lon=lon2)
+    brg = fmt._format_brg_spd(t).split()[0]
+    assert brg == "045"
+
+
+def test_expanded_formatting() -> None:
+    own = OwnshipRef(42.0, -71.0)
+    fmt = DataBlockFormatter(own)
+    t = make_track(
+        callsign="JBU123",
+        icao24="a1b2c3",
+        baro_alt_ft=34000.0,
+        vertical_rate_fpm=-1200.0,
+        ground_speed_kt=460.0,
+        emitter_type="L2J",
+    )
+    l1, l2, l3 = fmt.format_expanded(t)
+    assert l1 == "JBU123 | A1B2C3"
+    assert l2 == "340- | -1200"
+    assert l3.startswith("000 46 | L2J")  # bearing depends on lat/lon

--- a/tests/render/test_labels_layout.py
+++ b/tests/render/test_labels_layout.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from typing import List, Tuple
+
+from pocketscope.render.labels import DataBlockLayout
+
+
+def bbox(p: Tuple[int, int, int, int]) -> Tuple[int, int, int, int]:
+    return p
+
+
+def intersects(a: Tuple[int, int, int, int], b: Tuple[int, int, int, int]) -> bool:
+    ax, ay, aw, ah = a
+    bx, by, bw, bh = b
+    return not (ax + aw <= bx or bx + bw <= ax or ay + ah <= by or by + bh <= ay)
+
+
+def test_two_close_anchors_nudge_ne_se() -> None:
+    layout = DataBlockLayout((320, 480), font_px=12, line_gap_px=2, block_pad_px=2)
+    lines = ("ABC123", "350", "045 46")
+    items = [
+        ((160, 240), lines, False),
+        ((170, 245), lines, False),
+    ]
+    placements = layout.place_blocks(items)
+    assert len(placements) == 2
+    # Compute bboxes
+    bboxes: List[Tuple[int, int, int, int]] = []
+    for p in placements:
+        w, h = layout.measure(p.lines)
+        bboxes.append((p.x, p.y, w, h))
+    assert not intersects(bboxes[0], bboxes[1])
+
+
+def test_four_same_anchor_distinct_quadrants() -> None:
+    layout = DataBlockLayout((320, 480), font_px=12, line_gap_px=2, block_pad_px=2)
+    lines = ("ABC123", "350", "045 46")
+    items = [
+        ((160, 240), lines, False),
+        ((160, 240), lines, False),
+        ((160, 240), lines, False),
+        ((160, 240), lines, False),
+    ]
+    placements = layout.place_blocks(items)
+    assert len(placements) == 4
+    bboxes = []
+    for p in placements:
+        w, h = layout.measure(p.lines)
+        bboxes.append((p.x, p.y, w, h))
+    # Ensure no overlaps
+    for i in range(4):
+        for j in range(i + 1, 4):
+            assert not intersects(bboxes[i], bboxes[j])
+
+
+def test_expanded_block_wider_nudge_accounts_width() -> None:
+    layout = DataBlockLayout((320, 480), font_px=12, line_gap_px=2, block_pad_px=2)
+    std = ("ABC123", "350", "045 46")
+    exp = ("ABC123 | ABC123", "350 | +0", "045 46 | L2J")
+    items = [
+        ((160, 240), std, False),
+        ((162, 242), exp, True),
+    ]
+    placements = layout.place_blocks(items)
+    assert len(placements) == 2
+    bboxes = []
+    for p in placements:
+        w, h = layout.measure(p.lines)
+        bboxes.append((p.x, p.y, w, h))
+    assert not intersects(bboxes[0], bboxes[1])
+    # On-screen bounds
+    W, H = 320, 480
+    for x, y, w, h in bboxes:
+        assert 0 <= x <= W - w
+        assert 0 <= y <= H - h


### PR DESCRIPTION
## Summary
This PR introduces ATC-style three-line data blocks with leader lines to the PPI view and enables them by default in the live viewer. It adds a formatting and layout system for labels, exposes typography controls, and keeps a simple one-line label mode for minimal UI and deterministic testing.

Key highlights:
- New DataBlockFormatter (format rules) and DataBlockLayout (collision-aware placement) in `pocketscope.render.labels`.
- Live viewer (`examples/live_view.py`) defaults to data blocks; add flags to toggle/simple and adjust typography.
- PPI view integrates data blocks and leader lines with optional simple-label fallback.
- New tests for formatting and layout, plus updated golden frame.
- README expanded with usage and feature overview.

## Motivation
- Provide richer, ATC-like visualization with readable, standardized three-line data blocks.
- Demonstrate framework-agnostic Canvas text rendering with clear, testable rules.
- Preserve minimal label mode for compact displays and golden-test determinism.

## Scope of Changes
- README: document data blocks, leader lines, and CLI flags; refine examples.
- pyproject.toml: include top-level `tests/` in `pytest` testpaths.
- examples/live_view.py: defaults to data blocks; adds `--simple`, `--block-font-px`, `--block-line-gap-px`; passes kinematic fields to snapshots.
- render/fonts.py: new mono font helper (safe fallback if pygame unavailable).
- render/labels.py: new formatting and layout engine for data blocks.
- render/view_ppi.py: integrate data blocks, leader lines, and typography options; preserve legacy one-line labels when disabled.
- tests: add `tests/render/test_labels_format.py`, `tests/render/test_labels_layout.py`.
- tests/golden: update `src/pocketscope/tests/out/golden_ppi.png`.

## User-Facing Changes
- Live viewer now shows data blocks by default.
- New CLI flags:
  - `--simple`: use minimal one-line labels.
  - `--block-font-px <int>`: font size for data blocks (default 12 px).
  - `--block-line-gap-px <int>`: inter-line gap for data blocks (default -5 px in example; 2 px default in layout).
- README includes updated usage snippets and feature docs.

## API Changes (backward compatible)
- `pocketscope.render.view_ppi.PpiView` gains optional kwargs:
  - `show_data_blocks: bool = False`
  - `label_font_px: int = 12`
  - `label_line_gap_px: int = 2`
  - `label_block_pad_px: int = 2`
- `pocketscope.render.view_ppi.TrackSnapshot` adds optional fields used by the formatter:
  - `geo_alt_ft`, `baro_alt_ft`, `ground_speed_kt`, `vertical_rate_fpm`.
- New module `pocketscope.render.labels` exporting:
  - `DataBlockFormatter`, `DataBlockLayout`, `OwnshipRef`, and `TrackSnapshot` (labels-local type).

None of the above are breaking: defaults preserve prior behavior unless `show_data_blocks=True` (now used by the live viewer only).

## Data Block Rules (concise)
- 3 lines, monospace-oriented formatting.
- Line 1: CALLSIGN (or ICAO), uppercased.
- Line 2: Altitude in hundreds of feet, 3 digits (000–999), picks geometric else barometric; suffix `+` if vertical rate > +500 fpm, `-` if < -500 fpm.
- Line 3: `BRG SPD` where BRG is bearing from ownship (000–359), SPD is ground speed rounded to tens of kt as two digits (e.g., 452 kt → `45`).
- Expanded mode (not enabled in live viewer yet) adds ICAO, VS, and emitter type.

## Layout Rules (concise)
- Try quadrants NE/SE/NW/SW with small offsets from the glyph, compute top-left for a 3-line block measured in monospace.
- On overlap with previously placed blocks, nudge outward in a bounded spiral; clamp on-screen with small padding.
- Draw a leader line from aircraft glyph to nearest block edge center.

## How to Run (live viewer)
```bash
# Basic: 60 NM view with local dump1090
python -m pocketscope.examples.live_view \
  --url http://127.0.0.1:8080/data/aircraft.json \
  --center 42.0,-71.0 \
  --range 60

# Minimal labels instead of data blocks
python -m pocketscope.examples.live_view --simple

# Tweak data block typography
python -m pocketscope.examples.live_view --block-font-px 12 --block-line-gap-px -5
```

## Testing Instructions
- Unit tests:
```bash
pytest -q
```
- Focused runs:
  - Formatting rules: `tests/render/test_labels_format.py`
  - Layout rules: `tests/render/test_labels_layout.py`
- Golden frame:
  - Reference image updated at `src/pocketscope/tests/out/golden_ppi.png`.

## Performance Considerations
- Label layout is O(n²) worst-case due to pairwise overlap checks with previously placed blocks; bounded attempts per item (spiral) keep runtime small for typical track counts.
- Canvas text rendering remains lightweight; typography defaults chosen for clarity.

## Compatibility and Risks
- Live viewer default changed to data blocks (visual change only); `--simple` restores minimal mode.
- `PpiView` signature change is additive with defaults; existing callers unaffected unless relying on positional-only construction (still compatible).
- Layout measurements assume monospace; appearance can vary slightly across platforms; tests use string length, not font metrics.
- `render/fonts.py` is defensive: returns a stub if pygame isn’t available; Canvas.text does not require the handle.

## Documentation
- README updated with data block overview and CLI examples.

## Rollout / Migration
- No migration required for downstream code; optional kwargs are additive.
- Consumers wanting data blocks should pass `show_data_blocks=True` (already done by live viewer).

## Release Notes
- Add ATC-style data blocks with leader lines to PPI; enable by default in the live viewer; add formatting/layout engine and tests; expose typography controls and `--simple` flag.

## Checklist
- [x] Feature implemented with tests (formatting, layout).
- [x] README and usage updated.
- [x] Golden image refreshed to reflect defaults.
- [x] Backward compatibility verified (additive API).
