### PR TITLE
feat: add autoscale controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -969,6 +969,16 @@ Notes:
 
 Custom altitude filter bounds (user-defined min/max) are supported and tested (`tests/ui/test_altitude_filter_custom_bounds.py`).
 
+### Auto Scale Controller
+
+An optional controller can automatically adjust the map radius and altitude
+filter to keep roughly a target number of aircraft in view. When enabled via
+the `autoscale` block in `settings.json` it runs in the main loop and proposes
+zoom/altitude changes without performing any I/O. The controller exposes a
+`tick()` method and returns a dict of updates for the caller to apply. Tunables
+such as `target_count`, `zoom_step_factor_out`, and altitude ceilings all come
+from the `autoscale` settings block.
+
 ## File Formats
 
 ### ADS-B Trace Format (JSONL)

--- a/src/pocketscope/autoscale_controller.py
+++ b/src/pocketscope/autoscale_controller.py
@@ -1,0 +1,322 @@
+"""Automatic zoom and altitude filter controller.
+
+Implements an adaptive controller that keeps roughly N_target aircraft
+visible by adjusting map radius and altitude band. The controller is pure
+logic: callers supply state accessors via *state_adapter*.
+"""
+from __future__ import annotations
+
+import heapq
+import time
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+
+@dataclass
+class _Settings:
+    enabled: bool = True
+    target_count: int = 12
+    deadband_low_ratio: float = 0.8
+    deadband_high_ratio: float = 1.2
+    ema_alpha: float = 0.4
+    confirm_ticks: int = 2
+    radius_nm_min: float = 3.0
+    radius_nm_max: float = 60.0
+    zoom_step_factor_in: float = 0.8696
+    zoom_step_factor_out: float = 1.15
+    alt_min_floor_ft: int = 0
+    alt_max_ceiling_ft: int = 45000
+    alt_step_expand_ft: int = 2000
+    alt_margin_ft: int = 500
+    alt_min_band_ft: int = 1500
+    zoom_cooldown_s: float = 2.0
+    alt_cooldown_s: float = 2.5
+    max_changes_per_5s: int = 2
+    prefer_zoom_bias: float = 0.7
+    protect_focused: bool = True
+    include_high_when_quiet: bool = True
+
+
+def _snap_alt(value: float | int | None) -> int | None:
+    if value is None:
+        return None
+    v = int(round(float(value) / 500.0) * 500)
+    if v < 0:
+        v = 0
+    return v
+
+
+def _snap_radius(value: float | int | None) -> float | None:
+    if value is None:
+        return None
+    return float(value)
+
+
+class AutoScaleController:
+    """Adaptive auto-zoom/altitude controller."""
+
+    def __init__(
+        self, state_adapter: Any, settings: dict[str, Any] | None = None
+    ) -> None:
+        self._state = state_adapter
+        self._settings = _Settings(**(settings or {}))
+        self._ema: float | None = None
+        self._last_zoom_change: float = 0.0
+        self._last_alt_change: float = 0.0
+        self._over_ticks = 0
+        self._under_ticks = 0
+        self._recent_changes: list[float] = []
+        self._status: str = ""
+
+    # ------------------------------------------------------------------
+    def reload_settings(self, new_settings: dict[str, Any]) -> None:
+        self._settings = _Settings(**new_settings)
+
+    def reset(self) -> None:
+        self._ema = None
+        self._over_ticks = 0
+        self._under_ticks = 0
+        self._recent_changes.clear()
+        self._last_zoom_change = 0.0
+        self._last_alt_change = 0.0
+
+    # ------------------------------------------------------------------
+    def _count_visible(
+        self,
+        aircraft_list: Sequence[Any],
+        radius: float,
+        alt_min: int | None,
+        alt_max: int | None,
+    ) -> tuple[int, list[int]]:
+        visible = 0
+        alts: list[int] = []
+        in_view = getattr(self._state, "in_view", None)
+        for a in aircraft_list:
+            alt = self.alt(a)
+            if alt is None:
+                continue
+            if alt_min is not None and alt < alt_min:
+                continue
+            if alt_max is not None and alt >= alt_max:
+                continue
+            if callable(in_view):
+                try:
+                    if not in_view(a):
+                        continue
+                except Exception:
+                    continue
+            visible += 1
+            alts.append(int(alt))
+        return visible, alts
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def alt(a: Any) -> int | None:
+        for key in ("geo_alt", "baro_alt", "alt", "alt_ft"):
+            v = getattr(a, key, None) if not isinstance(a, dict) else a.get(key)
+            if isinstance(v, (int, float)):
+                return int(v)
+        return None
+
+    # ------------------------------------------------------------------
+    def status_string(self) -> str:
+        return self._status
+
+    # ------------------------------------------------------------------
+    def tick(
+        self,
+        aircraft_list: Sequence[Any],
+        focused: Any | None = None,
+        now: float | None = None,
+    ) -> dict[str, float | int | None]:
+        if not self._settings.enabled:
+            return {"radius_nm": None, "alt_min_ft": None, "alt_max_ft": None}
+        now = now if now is not None else time.monotonic()
+        radius = float(self._state.get_radius_nm())
+        alt_min, alt_max = self._state.get_alt_band_ft()
+        visible, alts = self._count_visible(aircraft_list, radius, alt_min, alt_max)
+
+        if self._ema is None:
+            self._ema = float(visible)
+        else:
+            alpha = float(self._settings.ema_alpha)
+            self._ema = alpha * float(visible) + (1.0 - alpha) * float(self._ema)
+
+        target = float(self._settings.target_count)
+        n_lo = target * float(self._settings.deadband_low_ratio)
+        n_hi = target * float(self._settings.deadband_high_ratio)
+        act: dict[str, float | int | None] = {
+            "radius_nm": None,
+            "alt_min_ft": None,
+            "alt_max_ft": None,
+        }
+
+        too_many = self._ema > n_hi
+        too_few = self._ema < n_lo
+        if too_many:
+            self._over_ticks += 1
+        else:
+            self._over_ticks = 0
+        if too_few:
+            self._under_ticks += 1
+        else:
+            self._under_ticks = 0
+        changed = False
+
+        def can_change(last: float, cooldown: float) -> bool:
+            if now - last < cooldown:
+                return False
+            # Limit aggregate changes per 5s window
+            self._recent_changes = [t for t in self._recent_changes if now - t < 5.0]
+            return len(self._recent_changes) < int(self._settings.max_changes_per_5s)
+
+        # Too many aircraft -------------------------------------------------
+        if self._over_ticks >= int(self._settings.confirm_ticks) and too_many:
+            # Prefer zoom
+            if radius > self._settings.radius_nm_min and can_change(
+                self._last_zoom_change, self._settings.zoom_cooldown_s
+            ):
+                radius = max(
+                    radius * float(self._settings.zoom_step_factor_in),
+                    self._settings.radius_nm_min,
+                )
+                act["radius_nm"] = _snap_radius(radius)
+                self._last_zoom_change = now
+                self._recent_changes.append(now)
+                changed = True
+            elif (
+                can_change(self._last_alt_change, self._settings.alt_cooldown_s)
+                and alts
+            ):
+                k = min(len(alts), int(target))
+                if k > 0:
+                    # altitude of N_target-th lowest
+                    thresh = heapq.nsmallest(k, alts)[-1]
+                    new_max = max(
+                        (alt_min or 0) + int(self._settings.alt_min_band_ft),
+                        thresh + int(self._settings.alt_margin_ft),
+                    )
+                    new_max = min(new_max, int(self._settings.alt_max_ceiling_ft))
+                    if alt_max is None or new_max < alt_max:
+                        act["alt_max_ft"] = _snap_alt(new_max)
+                        self._last_alt_change = now
+                        self._recent_changes.append(now)
+                        changed = True
+        # Too few aircraft --------------------------------------------------
+        elif self._under_ticks >= int(self._settings.confirm_ticks) and too_few:
+            if radius < self._settings.radius_nm_max and can_change(
+                self._last_zoom_change, self._settings.zoom_cooldown_s
+            ):
+                radius = min(
+                    radius * float(self._settings.zoom_step_factor_out),
+                    self._settings.radius_nm_max,
+                )
+                act["radius_nm"] = _snap_radius(radius)
+                self._last_zoom_change = now
+                self._recent_changes.append(now)
+                changed = True
+            elif can_change(self._last_alt_change, self._settings.alt_cooldown_s):
+                if alt_max is not None and alt_max < int(
+                    self._settings.alt_max_ceiling_ft
+                ):
+                    new_max = min(
+                        alt_max + int(self._settings.alt_step_expand_ft),
+                        int(self._settings.alt_max_ceiling_ft),
+                    )
+                    act["alt_max_ft"] = _snap_alt(new_max)
+                    self._last_alt_change = now
+                    self._recent_changes.append(now)
+                    changed = True
+                elif alt_min is not None and alt_min > int(
+                    self._settings.alt_min_floor_ft
+                ):
+                    new_min = max(
+                        int(self._settings.alt_min_floor_ft),
+                        alt_min - int(self._settings.alt_step_expand_ft),
+                    )
+                    act["alt_min_ft"] = _snap_alt(new_min)
+                    self._last_alt_change = now
+                    self._recent_changes.append(now)
+                    changed = True
+
+        # Focused aircraft protection --------------------------------------
+        if focused is not None and self._settings.protect_focused:
+            f_alt = self.alt(focused)
+            if f_alt is not None:
+                if act["alt_max_ft"] is not None and f_alt > int(act["alt_max_ft"]):
+                    act["alt_max_ft"] = _snap_alt(
+                        f_alt + int(self._settings.alt_margin_ft)
+                    )
+                elif (
+                    act["alt_max_ft"] is None
+                    and alt_max is not None
+                    and f_alt > alt_max
+                ):
+                    act["alt_max_ft"] = _snap_alt(
+                        f_alt + int(self._settings.alt_margin_ft)
+                    )
+                if hasattr(self._state, "ensure_in_view"):
+                    try:
+                        self._state.ensure_in_view(focused)
+                    except Exception:
+                        pass
+
+        # Update status string when changed
+        if changed:
+            r = act["radius_nm"] if act["radius_nm"] is not None else radius
+            lo = act["alt_min_ft"] if act["alt_min_ft"] is not None else alt_min
+            hi = act["alt_max_ft"] if act["alt_max_ft"] is not None else alt_max
+            lo_str = "0" if lo is None else str(int(lo / 1000)) + "k"
+            hi_str = "∞" if hi is None else str(int(hi / 1000)) + "k"
+            self._status = (
+                f"Auto: {visible} in view · {r:.0f} nm · {lo_str}-{hi_str} ft"
+            )
+        return act
+
+
+# ---------------------------------------------------------------------------
+def _demo() -> None:  # pragma: no cover - simple harness
+    import argparse
+    import random
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--demo", action="store_true")
+    args = parser.parse_args()
+    if not args.demo:
+        return
+    state = type("S", (), {})()
+    state.radius_nm = 10.0
+    state.alt_min_ft = 0
+    state.alt_max_ft = 45000
+    state.get_radius_nm = lambda: state.radius_nm
+    state.get_alt_band_ft = lambda: (state.alt_min_ft, state.alt_max_ft)
+
+    def in_view(a: tuple[float, float]) -> bool:
+        return a[0] <= float(state.radius_nm)
+
+    state.in_view = in_view
+
+    ctrl = AutoScaleController(state, {})
+    rng = random.Random(0)
+    now = 0.0
+    for i in range(60):
+        # ring of aircraft with distance alt
+        aircraft = [
+            (rng.uniform(0, 80), rng.uniform(0, 45000))
+            for _ in range(rng.randint(0, 40))
+        ]
+        ac_list = [{"geo_alt": alt, "dist": dist} for dist, alt in aircraft]
+        state.in_view = lambda a, st=state: a["dist"] <= st.radius_nm
+        updates = ctrl.tick(ac_list, now=now)
+        if updates["radius_nm"] is not None:
+            state.radius_nm = updates["radius_nm"]
+        if updates["alt_min_ft"] is not None:
+            state.alt_min_ft = updates["alt_min_ft"]
+        if updates["alt_max_ft"] is not None:
+            state.alt_max_ft = updates["alt_max_ft"]
+        print(f"{i:02d} {updates} {ctrl.status_string()}")
+        now += 1.0
+
+
+if __name__ == "__main__":  # pragma: no cover - demo entry
+    _demo()

--- a/src/pocketscope/ui/controllers.py
+++ b/src/pocketscope/ui/controllers.py
@@ -198,6 +198,23 @@ class UiController:
 
         # Softkeys (late-bound via set_softkeys)
         self._softkeys: SoftKeyBar | None = None
+
+        # Auto scale controller (optional)
+        try:
+            auto_cfg = {}
+            path = SettingsStore.settings_path()
+            raw = json.loads(path.read_text())
+            auto_cfg = raw.get("autoscale", {}) if isinstance(raw, dict) else {}
+        except Exception:
+            auto_cfg = {}
+        from pocketscope.autoscale_controller import AutoScaleController
+
+        self._autoscale: AutoScaleController | None
+        try:
+            self._autoscale = AutoScaleController(self, auto_cfg)
+        except Exception:
+            self._autoscale = None
+        self._autoscale_last = 0.0
         self._softkeys_base_actions: dict[str, Callable[[], None]] | None = None
 
         # Config change subscription & listener task
@@ -284,6 +301,38 @@ class UiController:
         self._softkeys.actions["Settings"] = _toggle_settings
         self._softkeys.layout()
 
+    # ------------------------------------------------------------------
+    # Autoscale adapter helpers
+    def get_radius_nm(self) -> float:
+        return float(self._cfg.range_nm)
+
+    def get_alt_band_ft(self) -> tuple[int | None, int | None]:
+        try:
+            lo = getattr(self._settings, "altitude_min_ft", None)
+            hi = getattr(self._settings, "altitude_max_ft", None)
+            if lo is not None:
+                lo = int(lo)
+            if hi is not None:
+                hi = int(hi)
+            return (lo, hi)
+        except Exception:
+            return (None, None)
+
+    def in_view(self, a: Any) -> bool:
+        try:
+            lat = a["lat"] if isinstance(a, dict) else getattr(a, "lat")
+            lon = a["lon"] if isinstance(a, dict) else getattr(a, "lon")
+            from pocketscope.core.geo import haversine_nm
+
+            return haversine_nm(
+                self._center_lat, self._center_lon, float(lat), float(lon)
+            ) <= float(self._cfg.range_nm)
+        except Exception:
+            return True
+
+    def ensure_in_view(self, target: Any) -> None:  # pragma: no cover - stub
+        pass
+
     async def run(self) -> None:
         self._running = True
         dt_target = 1.0 / max(1e-6, float(self._cfg.target_fps))
@@ -303,6 +352,22 @@ class UiController:
 
                 # Build snapshot of active tracks
                 snaps = self._build_snapshots()
+
+                # Autoscale controller tick (~1 Hz)
+                if self._autoscale is not None:
+                    t_ctrl = self._ts.monotonic()
+                    if t_ctrl - self._autoscale_last >= 1.0:
+                        upd = self._autoscale.tick(snaps, now=t_ctrl)
+                        self._autoscale_last = t_ctrl
+                        val = upd.get("radius_nm")
+                        if val is not None:
+                            self._cfg.range_nm = float(val)
+                        val = upd.get("alt_min_ft")
+                        if val is not None:
+                            self._settings.altitude_min_ft = val
+                        val = upd.get("alt_max_ft")
+                        if val is not None:
+                            self._settings.altitude_max_ft = val
 
                 # Render frame
                 canvas = self._display.begin_frame()

--- a/tests/test_autoscale_controller.py
+++ b/tests/test_autoscale_controller.py
@@ -1,0 +1,105 @@
+import random
+from pocketscope.autoscale_controller import AutoScaleController
+
+
+class DummyState:
+    def __init__(self, radius=10.0, alt_min=0, alt_max=45000):
+        self.radius_nm = radius
+        self.alt_min_ft = alt_min
+        self.alt_max_ft = alt_max
+
+    # state adapter API -------------------------------------------------
+    def get_radius_nm(self):
+        return self.radius_nm
+
+    def get_alt_band_ft(self):
+        return (self.alt_min_ft, self.alt_max_ft)
+
+    def in_view(self, a):
+        return a.get("dist", 0) <= self.radius_nm
+
+    def ensure_in_view(self, target):
+        pass
+
+
+# Helper to apply controller outputs back to state
+def apply(state, updates):
+    if updates["radius_nm"] is not None:
+        state.radius_nm = updates["radius_nm"]
+    if updates["alt_min_ft"] is not None:
+        state.alt_min_ft = updates["alt_min_ft"]
+    if updates["alt_max_ft"] is not None:
+        state.alt_max_ft = updates["alt_max_ft"]
+
+
+def make_ac(count, dist=5, alt=10000):
+    return [{"geo_alt": alt, "dist": dist} for _ in range(count)]
+
+
+def test_cooldowns():
+    state = DummyState(radius=10)
+    settings = {"target_count": 5, "radius_nm_max": 20.0, "confirm_ticks": 1}
+    ctrl = AutoScaleController(state, settings)
+    ac = make_ac(0)
+    out1 = ctrl.tick(ac, now=3.0)
+    apply(state, out1)
+    out2 = ctrl.tick(ac, now=3.5)
+    assert out2["radius_nm"] is None  # zoom cooldown
+    out3 = ctrl.tick(ac, now=6.5)
+    assert out3["radius_nm"] is not None
+
+
+def test_protects_focused_alt():
+    state = DummyState(radius=5, alt_min=0, alt_max=15000)
+    ctrl = AutoScaleController(state, {"confirm_ticks": 1})
+    aircraft = make_ac(40, dist=3, alt=12000)
+    focused = {"geo_alt": 30000, "dist": 2}
+    aircraft.append(focused)
+    out = ctrl.tick(aircraft, focused=focused, now=3.0)
+    assert out["alt_max_ft"] >= 30500
+
+
+def test_quiet_expands_alt():
+    state = DummyState(radius=60, alt_min=0, alt_max=10000)
+    settings = {"radius_nm_max": 60.0, "target_count": 10, "confirm_ticks": 1}
+    ctrl = AutoScaleController(state, settings)
+    ac = make_ac(1, dist=2, alt=15000)
+    out = ctrl.tick(ac, now=3.0)
+    assert out["alt_max_ft"] is not None and out["alt_max_ft"] > 10000
+
+
+def test_crowded_trims_alt():
+    state = DummyState(radius=3, alt_min=0, alt_max=45000)
+    settings = {"target_count": 12, "radius_nm_min": 3.0, "confirm_ticks": 1}
+    ctrl = AutoScaleController(state, settings)
+    aircraft = []
+    for i in range(1, 41):
+        aircraft.append({"geo_alt": i * 1000, "dist": 2})
+    out = ctrl.tick(aircraft, now=3.0)
+    assert out["alt_max_ft"] is not None
+    assert out["alt_max_ft"] <= 13000
+
+
+def test_converges_random():
+    state = DummyState(radius=10)
+    settings = {"target_count": 12, "confirm_ticks": 1}
+    ctrl = AutoScaleController(state, settings)
+    rng = random.Random(0)
+    now = 0.0
+    for _ in range(60):
+        n = rng.randint(0, 40)
+        aircraft = [{"geo_alt": rng.uniform(0, 40000), "dist": rng.uniform(0, 80)} for _ in range(n)]
+        updates = ctrl.tick(aircraft, now=now)
+        apply(state, updates)
+        now += 1.0
+    # Allow controller a few extra iterations on the last set to converge
+    for _ in range(10):
+        vis = sum(1 for a in aircraft if ctrl.alt(a) is not None and a["dist"] <= state.radius_nm)
+        n_lo = settings["target_count"] * 0.8
+        n_hi = settings["target_count"] * 1.2
+        if n_lo <= vis <= n_hi:
+            break
+        updates = ctrl.tick(aircraft, now=now)
+        apply(state, updates)
+        now += 1.0
+    assert n_lo <= vis <= n_hi


### PR DESCRIPTION
## Summary
- add adaptive AutoScaleController to manage range and altitude band
- integrate autoscale into UI loop with state adapter helpers
- document autoscale settings and provide tests

## Testing
- `pre-commit run --files src/pocketscope/autoscale_controller.py src/pocketscope/ui/controllers.py tests/test_autoscale_controller.py README.md`

------
https://chatgpt.com/codex/tasks/task_e_68c76c4756fc832f832406eafe44a51c